### PR TITLE
Add 'Custom/3rd Party Addon Fields' to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ If you are new to ACF Builder and would like to learn more, you can read my guid
 | [URL](#url)           | [Gallery](#gallery) |                              | [Taxonomy](#taxonomy)         | [Color Picker](#color-picker)         | [Repeater](#repeater)                 | [Conditions](#field-conditions)   |
 | [Password](#password) |                     |                              | [User](#user)                 |                                       | [Flexible Content](#flexible-content) | [Wrapper](#field-wrapper)         |
 |                       |                     |                              |                               |                                       |                                       | [Location](#field-group-location) |
-|                       |                     |                              |                               |                                       |                                       | [Position](#field-group-position) |
+| [Custom / 3rd Party](#composing-custom3rd-party-addon-fields) |    |       |                               |                                       |                                       | [Position](#field-group-position) |
+
 ## Field Types
 
 ### Basic
@@ -796,6 +797,20 @@ $builder
             ->setUnrequired()
         ->setConfig('placeholder' => 'Enter the title');
   ```
+
+### Composing Custom/3rd Party Addon Fields
+
+Add any other registered custom/[3rd party ACF Fields](https://www.advancedcustomfields.com/add-ons/) using the `addField($name, $type, $args)` method.
+
+```php
+$builder
+    ->addFields(new FieldsBuilder());
+
+$builder
+    ->addField('icon', 'font-awesome')
+        ->setLabel('My Icon')
+        ->setInstructions('Select an icon')
+        ->setConfig('save_format' => 'class')
 
 ### Modifying Fields
 ```php


### PR DESCRIPTION
Add 'Custom/3rd Party Addon Fields' to docs.

Moved PR / docs entry here, from [PR Add 3rd party add-on info to README](https://github.com/Log1x/acf-composer/pull/62) RE: [Issue: Add-ons support?](https://github.com/Log1x/acf-composer/issues/61)

The table of contents entry might be a bit weird, happy to move/remove it.