### PR TITLE
Fix message field syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ $builder
 #### Message
 ```php
 $builder
-    ->addMessage('message_field', [
+    ->addMessage('message_field', 'message', [
         'label' => 'Message Field',
         'instructions' => '',
         'required' => 0,
@@ -658,7 +658,7 @@ $builder
             'id' => '',
         ],
         'message' => '',
-        'new_lines' => 'wpautop',
+        'new_lines' => 'wpautop', // 'wpautop', 'br', '' no formmatting
         'esc_html' => 0,
     ]);
 ```

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ $builder
             'id' => '',
         ],
         'message' => '',
-        'new_lines' => 'wpautop', // 'wpautop', 'br', '' no formmatting
+        'new_lines' => 'wpautop', // 'wpautop', 'br', '' no formatting
         'esc_html' => 0,
     ]);
 ```


### PR DESCRIPTION
Seems `addMessage` field has a slightly different syntax to all the others..

Source: https://github.com/StoutLogic/acf-builder/blob/c207a3f75673448809c97af0dda7e3ffc9fdf56a/src/FieldsBuilder.php#L551-L560