### PR TITLE
Fixed markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ $builder
         ->setLabel('My Icon')
         ->setInstructions('Select an icon')
         ->setConfig('save_format', 'class')
+```
 
 ### Modifying Fields
 ```php


### PR DESCRIPTION
Commit fea920aa237a4521a4793b017cfd5bd1dd8ebfd5 didn't add extra <code>```</code> to close the code block (see here: https://github.com/Log1x/acf-builder-cheatsheet/pull/16/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R801-R814)