### PR TITLE
Add link to ACF field settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ If you are new to ACF Builder and would like to learn more, you can read my guid
 
 ## Field Types
 
+You can find a full reference of available settings on the [official ACF documentation](https://www.advancedcustomfields.com/resources/register-fields-via-php/#field-type%20settings).
+
 ### Basic
 
 #### Text


### PR DESCRIPTION
While your cheatsheet is an awesome reference to the ACF settings, the links provided for each field does not really help when it comes to registering fields programmatically. 

The link added is the most complete official (and only) reference I found on ACF docs. I think this might be useful to have it here somewhere.