### PR TITLE
Correct Field Group documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,9 +724,10 @@ $builder
           'class' => '',
           'id' => '',
         ],
-        'layout' => 'block',
-        'sub_fields' => [],
-    ]);
+        'layout' => 'block'
+    ])
+        ->addText('sub_field')
+    ->endGroup();
 ```
 [Official Documentation](https://www.advancedcustomfields.com/resources/group/)
 


### PR DESCRIPTION
There were a couple errors in the ->addGroup() documentation.

1. It was missing any mention of an `->endGroup()` being needed. 
2. It incorrectly showed how to add sub fields, if you nest them how the docs show they will never show up. They need nested in a similar manner to repeaters.